### PR TITLE
Add gocode commentary requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,13 +42,15 @@ If applied, this commit will _Your subject line here_
 For the submission of more substantial changes or additions, an issue should be opened outlining what is being proposed for implementation. The title of the issue should be descriptive and brief, follow the same rules as a commit message, as outlined above. The body of the issue should detail the reasoning for the need of the work to be carried out and the desired outcome.
 
 
-## Code Formatting
+## Code Formatting and Commentary
 
 ### Javascript
 All Javascript must be formatted with [ESLint](http://eslint.org/) using the JAAK [configuration](https://github.com/jaakmusic/eslint-config-jaak).
 
 ### Go
 Go code should match the output of `gofmt -s`.
+
+Go code must be documented adhering to the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
 
 ### Solidity
 All Solidity files must follow the style guide found [here](http://solidity.readthedocs.io/en/develop/style-guide.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ All Javascript must be formatted with [ESLint](http://eslint.org/) using the JAA
 ### Go
 Go code should match the output of `gofmt -s`.
 
-Go code must be documented adhering to the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
+Go code should be documented by following to the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
 
 ### Solidity
 All Solidity files must follow the style guide found [here](http://solidity.readthedocs.io/en/develop/style-guide.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ All Javascript must be formatted with [ESLint](http://eslint.org/) using the JAA
 ### Go
 Go code should match the output of `gofmt -s`.
 
-Go code should be documented by following to the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
+Go code should be documented by following the official Go [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
 
 ### Solidity
 All Solidity files must follow the style guide found [here](http://solidity.readthedocs.io/en/develop/style-guide.html).


### PR DESCRIPTION
Go code must be documented adhering to the official Go (https://golang.org/doc/effective_go.html#commentary) guidelines.