### PR TITLE
Add META Service Marketplace concept draft

### DIFF
--- a/concepts/marketplace.md
+++ b/concepts/marketplace.md
@@ -53,6 +53,7 @@ MetaService: {
 ```
 MetaService: {
   id: '0xabc...123',
+  available: true,
   displayName: 'Spotify',
   displayImage: ''data:image/jpeg;base64,/9j/4AA.../9k=',
   endpoints: {

--- a/concepts/marketplace.md
+++ b/concepts/marketplace.md
@@ -1,0 +1,72 @@
+# META Service Marketplace
+
+> An index of META Services available on the META Network
+
+## GraphQL API
+
+GraphQL APIs for reading and writing to a marketplace should be available on the
+network at known HTTP endpoints - eg.
+https://test.meta.network/marketplace/meta-id or
+https://test.meta.network/marketplace/smart-content
+
+#### Read
+```
+query {
+  # read all services in a marketplace
+  services() {
+    id
+  }
+
+  # read services by id or other filters
+  service(id: String, serviceType: String) {
+    name
+    type
+  }
+}
+```
+
+#### Write
+```
+mutation createMetaServiceMutation() {
+  # add a service to a marketplace
+  createMetaService(input: ServiceInput!) {
+    id
+  }
+}
+
+mutation removeMetaServiceMutation() {
+  # remove a service from a marketplace
+  removeMetaService(id: String!)
+}
+```
+
+### Simple example
+```
+MetaService: {
+  id: '0xabc...123',
+  name: 'spotify-id-claims',
+  type: 'IdentityClaim',
+}
+```
+
+### Extended example
+```
+MetaService: {
+  id: '0xabc...123',
+  displayName: 'Spotify',
+  displayImage: ''data:image/jpeg;base64,/9j/4AA.../9k=',
+  endpoints: {
+    development: 'http://localhost:7000',
+    testnet: 'https://test.meta.network/claims/spotify',
+    mainnet: 'https://meta.network/claims/spotify',
+  },
+  extraData: {
+    property: 'spotify.id'
+  },
+  stakeContract: { ...? },
+  name: 'spotify-id-claims',
+  type: 'IdentityClaim',
+  txPrice: '1.5',
+  website: 'https://spotify.com'
+}
+```


### PR DESCRIPTION
Initially raised as a proposal for META Identity Claims Services in https://github.com/meta-network/meta-identity-claims-service/issues/16, the concept of a marketplace for services in the network can be made into a generic model to allow for any type of service to be indexed.

The primary aim of a marketplace is to provide an index of available META Services that could be consumed via dapps and other interfaces. Currently, these clients must (manually) maintain their own local index of the services available.

The model should also allow for incentive mechanisms to be built into services and exposed via the marketplace data.